### PR TITLE
feat: dns resolvers

### DIFF
--- a/src/util/dns-resolvers/ali-dns-resolver.ts
+++ b/src/util/dns-resolvers/ali-dns-resolver.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+import { CustomDnsResolver } from "../../index";
+
+export const aliDnsResolver: CustomDnsResolver = async (domain) => {
+  const { data } = await axios({
+    method: "GET",
+    url: `https://dns.alidns.com/resolve?name=${domain}&type=16`,
+  });
+
+  return data;
+};

--- a/src/util/dns-resolvers/ali-dns-resolver.ts
+++ b/src/util/dns-resolvers/ali-dns-resolver.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { CustomDnsResolver } from "../../index";
+import { CustomDnsResolver } from "../..";
 
 export const aliDnsResolver: CustomDnsResolver = async (domain) => {
   const { data } = await axios({

--- a/src/util/dns-resolvers/cloudflare-dns-resolver.ts
+++ b/src/util/dns-resolvers/cloudflare-dns-resolver.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+import { CustomDnsResolver } from "../../index";
+
+export const cloudflareDnsResolver: CustomDnsResolver = async (domain) => {
+  const { data } = await axios({
+    method: "GET",
+    url: `https://cloudflare-dns.com/dns-query?name=${domain}&type=TXT`,
+    headers: { accept: "application/dns-json", contentType: "application/json", connection: "keep-alive" },
+  });
+  return data;
+};

--- a/src/util/dns-resolvers/cloudflare-dns-resolver.ts
+++ b/src/util/dns-resolvers/cloudflare-dns-resolver.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { CustomDnsResolver } from "../../index";
+import { CustomDnsResolver } from "../..";
 
 export const cloudflareDnsResolver: CustomDnsResolver = async (domain) => {
   const { data } = await axios({

--- a/src/util/dns-resolvers/google-dns-resolver.ts
+++ b/src/util/dns-resolvers/google-dns-resolver.ts
@@ -1,0 +1,11 @@
+import axios from "axios";
+import { CustomDnsResolver } from "../../index";
+
+export const googleDnsResolver: CustomDnsResolver = async (domain) => {
+  const { data } = await axios({
+    method: "GET",
+    url: `https://dns.google/resolve?name=${domain}&type=TXT`,
+  });
+
+  return data;
+};

--- a/src/util/dns-resolvers/google-dns-resolver.ts
+++ b/src/util/dns-resolvers/google-dns-resolver.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { CustomDnsResolver } from "../../index";
+import { CustomDnsResolver } from "../..";
 
 export const googleDnsResolver: CustomDnsResolver = async (domain) => {
   const { data } = await axios({

--- a/src/util/dns-resolvers/index.ts
+++ b/src/util/dns-resolvers/index.ts
@@ -1,2 +1,3 @@
 export * from "./google-dns-resolver";
 export * from "./cloudflare-dns-resolver";
+export * from "./ali-dns-resolver";

--- a/src/util/dns-resolvers/index.ts
+++ b/src/util/dns-resolvers/index.ts
@@ -1,0 +1,2 @@
+export * from "./google-dns-resolver";
+export * from "./cloudflare-dns-resolver";


### PR DESCRIPTION
## Summary

Add Ali DNS resolver as an opt-in resolver when required, particularly for traffic from China.

## Changes

- Separate the DNS resolvers into individual resolvers for customisation
- Add Ali DNS resolver

## Issues

- https://sgts.gitlab-dedicated.com/wog/gvt/gds-ace/general/dlt/galaxies-stories/trustdocs-stories/-/issues/290
